### PR TITLE
A couple small fixes to the layout and CSS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ public
 sass.old
 source.old
 source/_stash
-source/stylesheets/screen.css
+source/stylesheets
 vendor
 node_modules
 Gemfile.lock

--- a/sass/oscailte/custom/custom.scss
+++ b/sass/oscailte/custom/custom.scss
@@ -1,0 +1,1 @@
+body > footer { height: 64px; }

--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -1,6 +1,6 @@
 <p class="copyright">
   <span class="pull-left">
-    Contribute to these docs at <a href="//github.com/sparklemotion/nokogiri.org-tutorials">sparklemotion/nokogiri.org-tutorials</a>.
+    Contribute to these docs at <a href="//github.com/sparklemotion/nokogiri.org">sparklemotion/nokogiri.org</a>.
   </span>
   <span class="pull-right">
     Powered by <a href="//octopress.org/">Octopress</a>. Theme is <a href="//github.com/coogie/oscailte">Oscailte</a>.


### PR DESCRIPTION
- Fix the footer height (100px -> 64px) so the text is vertically centered.
- Change contributing URL to `sparklemotion/nokogiri.org` from `sparklemotion/nokogiri.org/tutorials`
