### PR TITLE
installation: add `patch` as dependency for Linux

### DIFF
--- a/source/tutorials/installing_nokogiri.md
+++ b/source/tutorials/installing_nokogiri.md
@@ -28,7 +28,7 @@ sudo apt-get install ruby1.8-dev ruby1.8 ri1.8 rdoc1.8 irb1.8
 sudo apt-get install libreadline-ruby1.8 libruby1.8 libopenssl-ruby
 
 # nokogiri requirements
-sudo apt-get install libxslt-dev libxml2-dev
+sudo apt-get install patch libxslt-dev libxml2-dev
 sudo gem install nokogiri
 ```
 
@@ -120,7 +120,7 @@ installed, you may be able to install nokogiri via `gem install`. If you run
 intro problems, try installing these packages as well.
 
 ```sh
-sudo yum install -y gcc ruby-devel libxml2 libxml2-devel libxslt libxslt-devel
+sudo yum install -y patch gcc ruby-devel libxml2 libxml2-devel libxslt libxslt-devel
 ```
 
 CentOS 5 (and RHEL5) come installed with libxml 2.6.26 which, while not as


### PR DESCRIPTION
Building nokogiri versions >=1.6.2 requires patching libraries.

Many Linux boxes don't have the `patch` binary installed,
and so I've added it as a dependency in your installation docs.

[discussion at stackoverflow](https://stackoverflow.com/questions/24251494/nokogiri-gem-installation-error/25939731#25939731)
