### PR TITLE
Fix Nokogiri::XML::ParseOptions example

### DIFF
--- a/source/tutorials/parsing_an_html_xml_document.md
+++ b/source/tutorials/parsing_an_html_xml_document.md
@@ -71,7 +71,7 @@ Or
 
 ```ruby
 doc = Nokogiri::XML(File.open("blossom.xml")) do |config|
-  config.options = Nokogiri::XML::ParseOptions.STRICT | Nokogiri::XML::ParseOptions.NONET
+  config.options = Nokogiri::XML::ParseOptions::STRICT | Nokogiri::XML::ParseOptions::NONET
 end
 ```
 


### PR DESCRIPTION
```
irb> Nokogiri::XML::ParseOptions.STRICT
NoMethodError: undefined method `STRICT' for Nokogiri::XML::ParseOptions:Class

irb> Nokogiri::XML::ParseOptions::STRICT
=> 0
```
