### PR TITLE
Add basic installation instructions for Fedora.

### DIFF
--- a/docs/tutorials/installing_nokogiri.md
+++ b/docs/tutorials/installing_nokogiri.md
@@ -75,6 +75,15 @@ gem install nokogiri --platform=ruby -- --use-system-libraries
 
   [RubyInstaller]: https://rubyinstaller.org/
 
+### Fedora
+
+The preferred way to install Nokogiri on Fedora is from system repositories
+using:
+
+```sh
+sudo dnf install -y rubygem-nokogiri
+```
+
 ### Red Hat / CentOS
 
 Install Nokogiri on a brand new Red Had / CentOS system with these commands:


### PR DESCRIPTION
These are just really basic instructions discussed in https://github.com/sparklemotion/nokogiri/issues/1983. Of course there could probably be recommendations to use `gem install nokogiri -- --use-system-libraries` as well as `gem install nokogiri`, but that would be just more confusing IMO.

