### PR TITLE
resolve xz error in alpine based distros

### DIFF
--- a/docs/tutorials/installing_nokogiri.md
+++ b/docs/tutorials/installing_nokogiri.md
@@ -475,6 +475,12 @@ On Debian/Ubuntu:
 sudo apt-get install xz-utils
 ```
 
+On Alpine:
+
+```sh
+apk add xz
+```
+
 If you have this problem on another system, please open an issue and give us some details so we can update this page.
 
 


### PR DESCRIPTION
Nokogiri fails to build when gems are compiled natively in alpine based docker images. This is due to the missing `xz` package needed to untar `libxml` and `libxslt`.


ref: https://github.com/chatwoot/chatwoot/issues/4045
