### PR TITLE
Packages xz and patch are needed on dnf-distros

### DIFF
--- a/docs/tutorials/installing_nokogiri.md
+++ b/docs/tutorials/installing_nokogiri.md
@@ -100,7 +100,7 @@ You may substitute `git` for `patch` (`mini_portile2` can use either for applyin
 #### Fedora, Red Hat, and CentOS
 
 ``` sh
-dnf install -y zlib-devel
+dnf install -y zlib-devel xz patch
 gem install nokogiri --platform=ruby
 ```
 


### PR DESCRIPTION
* Verified on `oraclelinux:9` that this is necessary.

Note: fixes https://nokogiri.org/tutorials/installing_nokogiri.html#fedora-red-hat-and-centos