### PR TITLE
`--use-system-libraries` requires the libraries to be installed

### DIFF
--- a/docs/tutorials/installing_nokogiri.md
+++ b/docs/tutorials/installing_nokogiri.md
@@ -190,7 +190,7 @@ If you're using macports and would like to contribute documentation, please open
 #### FreeBSD
 
 ``` sh
-sudo pkg install pkgconf
+sudo pkg install pkgconf libxml2 libxslt
 gem install nokogiri -- --use-system-libraries
 ```
 


### PR DESCRIPTION
On FreeBSD, `libxml2` and `libxslt` need to be installed in addition to `pkgconf`.