### PR TITLE
Use ucrt runtime

### DIFF
--- a/docs/tutorials/installing_nokogiri.md
+++ b/docs/tutorials/installing_nokogiri.md
@@ -208,7 +208,7 @@ gem install nokogiri -- --use-system-libraries
 We recommend installing Nokogiri against the MSYS2 system libraries:
 
 ``` sh
-ridk exec pacman -S mingw-w64-x86_64-libxslt
+ridk exec pacman -S mingw-w64-ucrt-x86_64-libxslt
 gem install nokogiri --platform=ruby -- --use-system-libraries
 ```
 


### PR DESCRIPTION
Recent RubyInstaller use "ucrt" runtime by default.

Thus need to update package.

See https://stackoverflow.com/a/79125327/12291425